### PR TITLE
feature: add --web.disable-exporter-metrics flag to control whether scrape go metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The `server` command runs the server required for prometheus to retrieve the sta
 |------------------------|-------------------------------------------------------|------------------------------|-----------------|
 | `--web.listen-address` | Address on which to expose metrics and web interface. | `PHP_FPM_WEB_LISTEN_ADDRESS` | [`:9253`](https://github.com/prometheus/prometheus/wiki/Default-port-allocations)         |
 | `--web.telemetry-path` | Path under which to expose metrics.                   | `PHP_FPM_WEB_TELEMETRY_PATH` | `/metrics`      |
+| `--web.disable-exporter-metrics` | Exclude metrics about the exporter itself (promhttp_*, process_*, go_*). | `PHP_FPM_WEB_DISABLE_EXPORTER_METRICS` | `false` |
 | `--phpfpm.scrape-uri`  | FastCGI address, e.g. unix:///tmp/php.sock;/status or tcp://127.0.0.1:9000/status | `PHP_FPM_SCRAPE_URI` | `tcp://127.0.0.1:9000/status` |
 | `--phpfpm.fix-process-count`  | Enable to calculate process numbers via php-fpm_exporter since PHP-FPM sporadically reports wrong active/idle/total process numbers. | `PHP_FPM_FIX_PROCESS_COUNT`| `false` |
 | `--log.level`          | Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] (default "error") | `PHP_FPM_LOG_LEVEL` | info |


### PR DESCRIPTION
https://github.com/hipages/php-fpm_exporter/issues/84