### PR TITLE
fix: add builds for ARM64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
 
 dockers:
   - image_templates:


### PR DESCRIPTION
**Summary**:
This changeset adds ARM64 as an additional architecture for releases.

**Context**:
I would like to use php-fpm_exporter on AWS' Graviton2-based servers (ARM64), but prebuilt binaries are not currently provided.

**Notes**:
I'm not familiar with golang or GitHub actions, but I was able to test this locally using gorelease and verify the built linux ARM64 binary worked as intended.