### PR TITLE
fix: Typo FPM_REQUEST_INFO

### DIFF
--- a/phpfpm/phpfpm.go
+++ b/phpfpm/phpfpm.go
@@ -40,8 +40,9 @@ const PoolProcessRequestFinishing string = "Finishing"
 // PoolProcessRequestReadingHeaders defines a process that is reading headers.
 const PoolProcessRequestReadingHeaders string = "Reading headers"
 
-// PoolProcessRequestInfo defines a process that is getting request information.
-const PoolProcessRequestInfo string = "Getting request information"
+// PoolProcessRequestInfo defines a process that is getting request information. Was changed in PHP 7.4 to PoolProcessRequestInfo74
+const PoolProcessRequestInfo string = "Getting request informations"
+const PoolProcessRequestInfo74 string = "Getting request information"
 
 // PoolProcessRequestEnding defines a process that is about to end.
 const PoolProcessRequestEnding string = "Ending"
@@ -230,6 +231,7 @@ func CountProcessState(processes []PoolProcess) (active int64, idle int64, total
 		case PoolProcessRequestEnding:
 		case PoolProcessRequestFinishing:
 		case PoolProcessRequestInfo:
+		case PoolProcessRequestInfo74:
 		case PoolProcessRequestReadingHeaders:
 			active++
 		default:

--- a/phpfpm/phpfpm.go
+++ b/phpfpm/phpfpm.go
@@ -41,7 +41,7 @@ const PoolProcessRequestFinishing string = "Finishing"
 const PoolProcessRequestReadingHeaders string = "Reading headers"
 
 // PoolProcessRequestInfo defines a process that is getting request information.
-const PoolProcessRequestInfo string = "Getting request informations"
+const PoolProcessRequestInfo string = "Getting request information"
 
 // PoolProcessRequestEnding defines a process that is about to end.
 const PoolProcessRequestEnding string = "Ending"


### PR DESCRIPTION
See `[FPM_REQUEST_INFO]            = "Getting request information",` in https://github.com/php/php-src/blob/07fa13088e1349f4b5a044faeee57f2b34f6b6e4/sapi/fpm/fpm/fpm_request.c#L27

Otherwise you can get error messages like `Unknown process state 'Getting request information'` in php-fpm_exporter. 
And indeed, "Getting request information" is unknown, as php-fpm_exporter is checking for "Getting request informations" (note the wrong plural "s")

This was changes in PHP >= 7.4 with https://github.com/php/php-src/commit/84b195d9fc5ba2b65ceb46d8ec3d4676bf51a538

Fixes #137 