### PR TITLE
Bump Alpine version to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
This upgrade introduces the following updates to Alpine including fixes to several CVEs

https://alpinelinux.org/posts/Alpine-3.13.2-released.html

Related issue:
https://github.com/hipages/php-fpm_exporter/issues/136