### PR TITLE
fix: generate gauge metrics for all states

### DIFF
--- a/phpfpm/exporter.go
+++ b/phpfpm/exporter.go
@@ -213,7 +213,20 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 		for childNumber, process := range pool.Processes {
 			childName := fmt.Sprintf("%d", childNumber)
-			ch <- prometheus.MustNewConstMetric(e.processState, prometheus.GaugeValue, 1, pool.Name, childName, process.State, pool.Address)
+			
+			states := map[string]int{
+				PoolProcessRequestIdle:           0,
+				PoolProcessRequestRunning:        0,
+				PoolProcessRequestFinishing:      0,
+				PoolProcessRequestReadingHeaders: 0,
+				PoolProcessRequestInfo:           0,
+				PoolProcessRequestEnding:         0,
+			}
+			states[process.State]++
+
+			for stateName, inState := range states {
+				ch <- prometheus.MustNewConstMetric(e.processState, prometheus.GaugeValue, float64(inState), pool.Name, childName, stateName, pool.Address)
+			}
 			ch <- prometheus.MustNewConstMetric(e.processRequests, prometheus.CounterValue, float64(process.Requests), pool.Name, childName, pool.Address)
 			ch <- prometheus.MustNewConstMetric(e.processLastRequestMemory, prometheus.GaugeValue, float64(process.LastRequestMemory), pool.Name, childName, pool.Address)
 			ch <- prometheus.MustNewConstMetric(e.processLastRequestCPU, prometheus.GaugeValue, process.LastRequestCPU, pool.Name, childName, pool.Address)


### PR DESCRIPTION
https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics
The recommended way is to return all possible metrics even if their value is zero

Currently exporter return only non-zero metrics which leads to incorrect values in historical data in prometheus

This is a fix for #123 