### PR TITLE
Rename and fix metric names and types

### DIFF
--- a/phpfpm/phpfpm.go
+++ b/phpfpm/phpfpm.go
@@ -221,7 +221,7 @@ func JSONResponseFixer(content []byte) []byte {
 }
 
 // CountProcessState return the calculated metrics based on the reported processes.
-func CountProcessState(processes []PoolProcess) (active int64, idle int64, total int64) {
+func CountProcessState(processes []PoolProcess) (active int64, idle int64) {
 	for idx := range processes {
 		switch processes[idx].State {
 		case PoolProcessRequestRunning:
@@ -239,7 +239,7 @@ func CountProcessState(processes []PoolProcess) (active int64, idle int64, total
 		}
 	}
 
-	return active, idle, active + idle
+	return active, idle
 }
 
 // parseURL creates elements to be passed into fcgiclient.DialTimeout

--- a/phpfpm/phpfpm_test.go
+++ b/phpfpm/phpfpm_test.go
@@ -30,11 +30,10 @@ func TestCountProcessState(t *testing.T) {
 		{State: PoolProcessRequestEnding},
 	}
 
-	active, idle, total := CountProcessState(processes)
+	active, idle := CountProcessState(processes)
 
 	assert.Equal(t, int64(2), active, "active processes")
 	assert.Equal(t, int64(1), idle, "idle processes")
-	assert.Equal(t, int64(3), total, "total processes")
 }
 
 // https://github.com/hipages/php-fpm_exporter/issues/10


### PR DESCRIPTION
Here are a few changes that should bring this exporter closer to Prometheus best practices.

- `phpfpm_scrape_failures` is a counter and should end with _total. It has been renamed to `phpfpm_scrape_failures_total` (https://prometheus.io/docs/instrumenting/writing_exporters/#naming) 
- `phpfpm_start_since` has been renamed to `phpfpm_start_time_seconds` to match standard `process_start_time_seconds` and contain unit. It has been changed to a gauge (https://www.robustperception.io/are-increasing-timestamps-counters-or-gauges).
- `phpfpm_accepted_connections` is a counter and should end with _total. It has been renamed to `phpfpm_accepted_connections_total`.
- `phpfpm_idle_processes`, `phpfpm_active_processes` have been changed to `phpfpm_processes{state="active"}` and `phpfpm_processes{state="idle"}`.
- `phpfpm_total_processes` has been dropped because it can be found as `sum without(state) phpfpm_processes`.
- `phpfpm_max_children_reached` is a counter and should end with _total, so it has been renamed to `phpfpm_max_children_reached_total`.
- `process_last_request_memory` should contain the unit, so it has been renamed to `process_last_request_memory_bytes`.
- `process_request_duration` has been normalized to seconds and renamed `phpfpm_process_last_request_duration_seconds`.