### PR TITLE
Fix lint check & update golangci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2.5.2
       with:
-        version: v1.32
+        version: v1.43
 
   test:
     name: Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,16 +13,16 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
+#    - interfacer
 #    - lll
     - misspell
     - nakedret
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
 #    - typecheck

--- a/phpfpm/exporter.go
+++ b/phpfpm/exporter.go
@@ -213,7 +213,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 		for childNumber, process := range pool.Processes {
 			childName := fmt.Sprintf("%d", childNumber)
-			
+
 			states := map[string]int{
 				PoolProcessRequestIdle:           0,
 				PoolProcessRequestRunning:        0,


### PR DESCRIPTION
golint linter is deprecated & you should switch to revive https://github.com/mgechev/revive. also some other linters

here is the warnings i fixed 

```zsh
$ golangci-lint run
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
WARN [runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
```