### PR TITLE
feat: create multiarch docker images using buildx

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,15 +11,43 @@ builds:
       - arm64
 
 dockers:
-  - image_templates:
-      - "hipages/php-fpm_exporter:latest"
-      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}"
-      - "hipages/php-fpm_exporter:{{ .Major }}"
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
     build_flag_templates:
+      - "--platform=linux/amd64"
       - "--build-arg=VERSION={{.Version}}"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=VERSION={{.Version}}"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+docker_manifests:
+  - name_template: "hipages/php-fpm_exporter:latest"
+    image_templates:
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
+  - name_template: "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
+    image_templates:
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
+  - name_template: "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
+  - name_template: "hipages/php-fpm_exporter:{{ .Major }}"
+    image_templates:
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
+      - "hipages/php-fpm_exporter:{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
 
 changelog:
   filters:


### PR DESCRIPTION
php-fpm_exporter release script makes multiple binary files for different architectures but only AMD64 docker image. This change adds support for the arm64 docker image building and pushing it to the docker hub with the same name.