### PR TITLE
:book: Actualize link to the test GitHub workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # php-fpm_exporter
 
-![Test](https://github.com/hipages/php-fpm_exporter/workflows/Test/badge.svg)
+![Test](https://github.com/hipages/php-fpm_exporter/actions/workflows/test_push.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hipages/php-fpm_exporter)](https://goreportcard.com/report/github.com/hipages/php-fpm_exporter)
 [![GoDoc](https://godoc.org/github.com/hipages/php-fpm_exporter?status.svg)](https://godoc.org/github.com/hipages/php-fpm_exporter)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=hipages_php-fpm_exporter&metric=alert_status)](https://sonarcloud.io/dashboard?id=hipages_php-fpm_exporter)


### PR DESCRIPTION
The previous link led to the 404.

This PR for now tries to initiate a discussion - why there's no recorded runs [1] of "test_push.yml" workflow [2]?

[1] https://github.com/hipages/php-fpm_exporter/actions/workflows/test_push.yml
[2] https://github.com/hipages/php-fpm_exporter/blob/master/.github/workflows/test_push.yml