### PR TITLE
Add port spec to docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you like to have a more granular reporting please use `phpfpm_process_state`.
 * Run docker manually
   ```
   docker pull hipages/php-fpm_exporter
-  docker run -it --rm -e PHP_FPM_SCRAPE_URI="tcp://127.0.0.1:9000/status,tcp://127.0.0.1:9001/status" hipages/php-fpm_exporter
+  docker run -it --rm -p 9253:9253 -e PHP_FPM_SCRAPE_URI="tcp://127.0.0.1:9000/status,tcp://127.0.0.1:9001/status" hipages/php-fpm_exporter
   ```
 
 * Run the docker-compose example


### PR DESCRIPTION
Stumbled on this while testing, w/o the por spec in docker run example the port is not publised to localhost so the posterior `curl` open browser can't connect to metrics. 

It adds ergonomics for new people, as copy and paste just works